### PR TITLE
Using enmerkar latest ver instead of commit hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,14 @@ install:
 
 script:
   - tox -e $TOX_ENV
+
+deploy:
+  provider: pypi
+  user: edx
+  password:
+    secure:
+  distributions: sdist bdist_wheel
+  on:
+    tags: true
+    python: 3.5
+    condition: $TOXENV = django22

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+1.0.0 (2020-05-29)
+------------------
+
+* Rename the repo
+* Using latest version of enmerkar.
+* Release of pypi
+
 0.6.0 (2020-01-07)
 ------------------
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,3 +5,4 @@
 django
 babel>=1.3
 markey>=0.8,<0.9
+enmerkar==0.7.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-babel==2.8.0
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.12
-markey==0.8
+babel==2.8.0              # via -r requirements/base.in, enmerkar
+django==2.2.12            # via -r requirements/base.in, enmerkar
+enmerkar==0.7.1           # via -r requirements/base.in
+markey==0.8               # via -r requirements/base.in
 pytz==2020.1              # via babel, django
 sqlparse==0.3.1           # via django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,45 +7,44 @@
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
-babel==2.8.0
+babel==2.8.0              # via -r requirements/base.in, enmerkar, sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.1
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.12
+coverage==5.1             # via -r requirements/test.in, pytest-cov, python-coveralls
+django==2.2.12            # via -r requirements/base.in, enmerkar
 docutils==0.16            # via sphinx
-entrypoints==0.3          # via flake8
+enmerkar==0.7.1           # via -r requirements/base.in
 execnet==1.7.1            # via pytest-cache
-flake8==3.7.9
+flake8==3.8.1             # via -r requirements/test.in
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via pluggy, pytest
+importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 jinja2==2.11.2            # via sphinx
-markey==0.8
+markey==0.8               # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
-packaging==20.3           # via pytest, sphinx
+more-itertools==8.3.0     # via pytest
+packaging==20.4           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8, pytest-flakes
+pycodestyle==2.6.0        # via flake8
+pyflakes==2.2.0           # via flake8, pytest-flakes
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
-pytest-cov==2.8.1
-pytest-flakes==4.0.0
-pytest-pep8==1.0.6
-pytest==5.4.1
-python-coveralls==2.9.3
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-flakes==4.0.0      # via -r requirements/test.in
+pytest-pep8==1.0.6        # via -r requirements/test.in
+pytest==5.4.2             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-flakes, pytest-pep8
+python-coveralls==2.9.3   # via -r requirements/test.in
 pytz==2020.1              # via babel, django
 pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
-six==1.14.0               # via packaging, pathlib2, python-coveralls
+six==1.15.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3
+sphinx==3.0.3             # via -r requirements/test.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,2 +1,0 @@
-# As latest version of enmerkar does not support old versions of django<2.2
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.2
-six==1.14.0               # via pip-tools
+pip-tools==5.1.2          # via -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,45 +7,44 @@
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
-babel==2.8.0
+babel==2.8.0              # via -r requirements/base.in, enmerkar, sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.1
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
-django==2.2.12
+coverage==5.1             # via -r requirements/test.in, pytest-cov, python-coveralls
+django==2.2.12            # via -r requirements/base.in, enmerkar
 docutils==0.16            # via sphinx
-entrypoints==0.3          # via flake8
+enmerkar==0.7.1           # via -r requirements/base.in
 execnet==1.7.1            # via pytest-cache
-flake8==3.7.9
+flake8==3.8.1             # via -r requirements/test.in
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via pluggy, pytest
+importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 jinja2==2.11.2            # via sphinx
-markey==0.8
+markey==0.8               # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
-packaging==20.3           # via pytest, sphinx
+more-itertools==8.3.0     # via pytest
+packaging==20.4           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8, pytest-flakes
+pycodestyle==2.6.0        # via flake8
+pyflakes==2.2.0           # via flake8, pytest-flakes
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
-pytest-cov==2.8.1
-pytest-flakes==4.0.0
-pytest-pep8==1.0.6
-pytest==5.4.1
-python-coveralls==2.9.3
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-flakes==4.0.0      # via -r requirements/test.in
+pytest-pep8==1.0.6        # via -r requirements/test.in
+pytest==5.4.2             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-flakes, pytest-pep8
+python-coveralls==2.9.3   # via -r requirements/test.in
 pytz==2020.1              # via babel, django
 pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
-six==1.14.0               # via packaging, pathlib2, python-coveralls
+six==1.15.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3
+sphinx==3.0.3             # via -r requirements/test.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,44 +7,43 @@
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
 attrs==19.3.0             # via pytest
-babel==2.8.0
+babel==2.8.0              # via -r requirements/base.in, enmerkar, sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-coverage==5.1
-git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
+coverage==5.1             # via -r requirements/test.in, pytest-cov, python-coveralls
 docutils==0.16            # via sphinx
-entrypoints==0.3          # via flake8
+enmerkar==0.7.1           # via -r requirements/base.in
 execnet==1.7.1            # via pytest-cache
-flake8==3.7.9
+flake8==3.8.1             # via -r requirements/test.in
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via pluggy, pytest
+importlib-metadata==1.6.0  # via flake8, pluggy, pytest
 jinja2==2.11.2            # via sphinx
-markey==0.8
+markey==0.8               # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
-packaging==20.3           # via pytest, sphinx
+more-itertools==8.3.0     # via pytest
+packaging==20.4           # via pytest, sphinx
 pathlib2==2.3.5           # via pytest
 pep8==1.7.1               # via pytest-pep8
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1           # via flake8, pytest-flakes
+pycodestyle==2.6.0        # via flake8
+pyflakes==2.2.0           # via flake8, pytest-flakes
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest-cache==1.0         # via pytest-pep8
-pytest-cov==2.8.1
-pytest-flakes==4.0.0
-pytest-pep8==1.0.6
-pytest==5.4.1
-python-coveralls==2.9.3
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-flakes==4.0.0      # via -r requirements/test.in
+pytest-pep8==1.0.6        # via -r requirements/test.in
+pytest==5.4.2             # via -r requirements/test.in, pytest-cache, pytest-cov, pytest-flakes, pytest-pep8
+python-coveralls==2.9.3   # via -r requirements/test.in
 pytz==2020.1              # via babel, django
 pyyaml==5.3.1             # via python-coveralls
 requests==2.23.0          # via python-coveralls, sphinx
-six==1.14.0               # via packaging, pathlib2, python-coveralls
+six==1.15.0               # via packaging, pathlib2, python-coveralls
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3
+sphinx==3.0.3             # via -r requirements/test.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import codecs
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-version = '0.6.1'
+version = '1.0.0'
 
 
 def read(*parts):
@@ -58,13 +58,13 @@ def is_requirement(line):
 
 
 setup(
-    name='django-babel-underscore',
+    name='enmerkar-underscore',
     version=version,
     description='Implements a underscore extractor for django-babel.',
     long_description=read('README.rst') + u'\n\n' + read('HISTORY.rst'),
-    author='Christopher Grebs',
-    author_email='cg@webshox.org',
-    url='https://github.com/EnTeQuAk/django-babel-underscore',
+    author='edX',
+    author_email='oscm@edx.org',
+    url='https://github.com/edx/enmerkar-underscore',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
@@ -72,13 +72,13 @@ setup(
     install_requires=load_requirements('requirements/base.in'),
     entry_points="""
     [babel.extractors]
-    underscore = django_babel_underscore:extract
+    underscore = enmerkar_underscore:extract
     """,
     zip_safe=False,
     license='BSD',
-    keywords='django-babel-underscore',
+    keywords='enmerkar-underscore',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',

--- a/src/enmerkar_underscore/__init__.py
+++ b/src/enmerkar_underscore/__init__.py
@@ -12,7 +12,7 @@ else:  # django < 2.1
     from django.template.base import TOKEN_TEXT
 
 from django.utils.encoding import force_text
-from django_babel.extract import extract_django
+from enmerkar.extract import extract_django
 from markey import underscore
 from markey.tools import TokenStream
 from markey.machine import tokenize, parse_arguments

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,8 +2,7 @@
 import pytest
 from babel._compat import BytesIO
 
-from django_babel_underscore import extract
-
+from enmerkar_underscore import extract
 
 class TestMixedExtract:
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -3,7 +3,7 @@ import pytest
 from babel._compat import BytesIO
 from babel.messages.extract import DEFAULT_KEYWORDS
 
-from django_babel_underscore import extract
+from enmerkar_underscore import extract
 
 
 class TestMixedExtract:


### PR DESCRIPTION
Using enmerkar latest ver instead of commit hash
Rename the repo name.
update setup information.

https://openedx.atlassian.net/browse/BOM-1637